### PR TITLE
Fix tabs

### DIFF
--- a/meow_emoji.dict.yaml
+++ b/meow_emoji.dict.yaml
@@ -47,6 +47,7 @@ o<(=′益`=)>o	nanshou
 <(=ˉ^ˉ=)>	hengheng
 Pia!<(=ｏ ‵-′)ノ☆	pia
 ☆乀(‵-′ ｏ=)> Pia!	pia
+Pia! ☆乀<(=‵-′=)>ノ☆ Pia!	pia
 ～(￣▽￣～=)><(=～￣▽￣)～	deyi
 <(=￣ˇ￣)/	deyi
 <(= ￣O￣=)ノノ……∞∞OOO)))	gongji

--- a/meow_emoji.dict.yaml
+++ b/meow_emoji.dict.yaml
@@ -7,7 +7,7 @@ version: "0.1"
 sort: original
 ...
 
-┗<(=｀O′=)>┛  aowu
+┗<(=｀O′=)>┛ 	aowu
 ｍ<(＿　＿)>ｍ	mobai
 <(=′▽')爻 (`▽｀=)>	baobao
 <(=*′д｀)爻(′д｀*=)>	baobao
@@ -209,5 +209,5 @@ o<(=╯□╰=)>o	jiong
 ๐<(=๏ᆷ๏=)>๐	ha
 <(=/๑ᆷ๑\)	buyao
 <(=OᆸO=)>	ha
-<(=ﾟ∀ﾟ)σ  nikankanni
-<(=˚_˚=)> fadai
+<(=ﾟ∀ﾟ)σ	nikankanni
+<(=˚_˚=)>	fadai

--- a/meow_emoji.dict.yaml
+++ b/meow_emoji.dict.yaml
@@ -209,5 +209,5 @@ o<(=╯□╰=)>o	jiong
 ๐<(=๏ᆷ๏=)>๐	ha
 <(=/๑ᆷ๑\)	buyao
 <(=OᆸO=)>	ha
-<(=ﾟ∀ﾟ)σ nikankanni
+<(=ﾟ∀ﾟ)σ  nikankanni
 <(=˚_˚=)> fadai

--- a/meow_emoji.dict.yaml
+++ b/meow_emoji.dict.yaml
@@ -46,6 +46,7 @@ o<(=′益`=)>o	nanshou
 <(=￣.￣=)>	danding
 <(=ˉ^ˉ=)>	hengheng
 Pia!<(=ｏ ‵-′)ノ☆	pia
+☆乀(‵-′ ｏ=)> Pia!	pia
 ～(￣▽￣～=)><(=～￣▽￣)～	deyi
 <(=￣ˇ￣)/	deyi
 <(= ￣O￣=)ノノ……∞∞OOO)))	gongji


### PR DESCRIPTION
Mixing spaces with tab prevents RIME from reading emojis correctly.
